### PR TITLE
fix: describe behaviour when using a query containing slashes

### DIFF
--- a/docs/source/SOULSEEK.rst
+++ b/docs/source/SOULSEEK.rst
@@ -416,6 +416,7 @@ Undescribed rules (matching):
 * Wildcard: doesn't need to match a character. Query ``*song.mp3`` will match ``song.mp3```
 * Wildcard: query ``song *`` will return something
 * Exclusion: there are results for queries using only exclusions but it does not seem official. Example ``-mp3``, returns a limited number of results and some results even containing string ``mp3``
+* Path seperators can be included (backslash and forward slash) but only apply to the directory part of the filename. Query ``my\cool`` will match file ``my\cool\band\song.mp3``, but query ``band\song`` will not match the same file
 
 The algorithm for matching can be described as:
 

--- a/src/aioslsk/shares/model.py
+++ b/src/aioslsk/shares/model.py
@@ -95,7 +95,7 @@ class SharedItem:
 
     def get_query_path(self) -> str:
         """Returns the query-able part of the `SharedItem`"""
-        return os.path.join(self.subdir, self.filename)
+        return normalize_remote_path(os.path.join(self.subdir, self.filename))
 
     def __getstate__(self):
         fields = self.__dict__.copy()

--- a/tests/unit/shares/test_shares_manager.py
+++ b/tests/unit/shares/test_shares_manager.py
@@ -265,6 +265,29 @@ class TestSharesManagerQuery:
         assert expected_items == unordered(actual_items)
         assert locked_items == []
 
+    @pytest.mark.parametrize(
+        'query,expected_items',
+        [
+            # Backslash, inclusion, directory
+            ('song folk\\folkalbum', ['item1']),
+            # Backslash exclusion, directory
+            ('song -folk\\folkalbum', ['item2', 'item3']),
+            # Backslash, inclusion, filename
+            ('folkalbum, release\\simple band', ['item1']),
+            # Backslash, exclusion, filename
+            ('song -rapalbum_release\\simple band', ['item1', 'item2']),
+            # Slash inclusion
+            ('song folk/folkalbum', []),
+            # Slash exclusion
+            ('song -folk/folkalbum', ['item1', 'item2', 'item3']),
+        ]
+    )
+    def test_queryTermsWithSlashes(self, manager_query: SharesManager, query: str, expected_items: List[str]):
+        expected_items = [SHARED_ITEMS[item_name] for item_name in expected_items]
+        actual_items, locked_items = manager_query.query(query)
+        assert expected_items == unordered(actual_items)
+        assert locked_items == []
+
     def test_maxResults(self, manager_query: SharesManager):
         # Get the results without any limit, this is simply to ensure that if
         # the test data is changed that this testcase doesn't become bogus


### PR DESCRIPTION
Resolves #213 